### PR TITLE
Edits to compile. No functional change intended.

### DIFF
--- a/src/fibonacci_heap.rs
+++ b/src/fibonacci_heap.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::num::Float;
 
 use super::fibonacci_node::FibonacciNodeType;
 use super::fibonacci_node::FibNode;
@@ -157,7 +156,7 @@ impl<K, V> FibonacciHeap<K, V>
     // }
     
     fn consolidate(&mut self) -> () {
-        let base: f64 = (1.0 + 5.0.sqrt())/2.0;
+        let base: f64 = (1.0 + 5.0f64.sqrt())/2.0;
         let log_n = (self.size as f64).log(base) as usize + 1;
         let mut array: Vec<Option<FibonacciNodeType<K, V>>> = (0..log_n).map(|_| None).collect();
         

--- a/src/fibonacci_node.rs
+++ b/src/fibonacci_node.rs
@@ -2,9 +2,10 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::collections::LinkedList;
 
-pub type FibonacciNodeType<K, V> = Rc<RefCell<FibonacciNode<K, V>>>;
+#[derive (Clone)]
+pub struct FibonacciNodeType<K, V> (Rc<RefCell<FibonacciNode<K, V>>>);
 
-pub trait FibNode<K, V> {
+pub trait FibNode<K, V>: Sized {
     fn new(key: K, value: V) -> Self;
     fn get_key(&self) -> K;
     fn set_key(&self, key: K) -> ();
@@ -35,59 +36,59 @@ impl<K, V> FibNode<K, V> for FibonacciNodeType<K, V>
           V: Clone + Eq
 {
     fn new(key: K, value: V) -> FibonacciNodeType<K, V> {
-        Rc::new(RefCell::new(FibonacciNode {
+        FibonacciNodeType(Rc::new(RefCell::new(FibonacciNode {
             key: key,
             value: value,
             marked: false,
             parent: None,
             children: LinkedList::new()
-        }))
+        })))
     }
     
     fn get_key(&self) -> K {
-        self.borrow().key.clone()
+        self.0.borrow().key.clone()
     }
     
     fn set_key(&self, key: K) -> () {
-        self.borrow_mut().key = key;
+        self.0.borrow_mut().key = key;
     }
     
     fn get_value(&self) -> V {
-        self.borrow().value.clone()
+        self.0.borrow().value.clone()
     }
     
     fn rank(&self) -> usize {
-        self.borrow().children.len()
+        self.0.borrow().children.len()
     }
     
     fn is_marked(&self) -> bool {
-        self.borrow().marked
+        self.0.borrow().marked
     }
     
     fn set_marked(&self, marked: bool) -> () {
-        self.borrow_mut().marked = marked;
+        self.0.borrow_mut().marked = marked;
     }
     
     fn get_parent(&self) -> Option<FibonacciNodeType<K, V>> {
-        self.borrow().parent.clone()
+        self.0.borrow().parent.clone()
     }
     
     fn set_parent(&self, parent: Option<FibonacciNodeType<K, V>>) -> () {
-        self.borrow_mut().parent = parent;
+        self.0.borrow_mut().parent = parent;
     }
     
     fn add_child(&self, child: FibonacciNodeType<K, V>) -> () {
-        self.borrow_mut().children.push_back(child);
+        self.0.borrow_mut().children.push_back(child);
     }
     
     fn remove_child(&self, child: FibonacciNodeType<K, V>) -> Option<FibonacciNodeType<K, V>> {
-        let children = &mut self.borrow_mut().children;
+        let children = &mut self.0.borrow_mut().children;
         
         remove_element(children, child)
     }
     
     fn get_children(&self) -> LinkedList<FibonacciNodeType<K, V>> {
-        self.borrow().children.clone()
+        self.0.borrow().children.clone()
     }
 }
 
@@ -96,7 +97,7 @@ impl<K, V> PartialEq for FibonacciNodeType<K, V>
           V: Eq
 {
     fn eq(&self, other: &FibonacciNodeType<K, V>) -> bool {
-        self.borrow().value == other.borrow().value && self.borrow().key == other.borrow().key
+        self.0.borrow().value == other.0.borrow().value && self.0.borrow().key == other.0.borrow().key
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use self::fibonacci_node::FibonacciNodeType;
 pub use self::fibonacci_heap::FibonacciHeap;
 
 mod fibonacci_heap;


### PR DESCRIPTION
Change FibonacciNodeType from 'type' to 'struct' in order to impl PartialEq. Otherwise, the type is an Rc and the compile fails because either the trait or the type needs to be local.

Other changes were implementing compiler suggestions.